### PR TITLE
fix for build with "--with-external-libupnp" config flag

### DIFF
--- a/djmount/file_buffer.c
+++ b/djmount/file_buffer.c
@@ -212,7 +212,7 @@ FileBuffer_Read (FileBuffer* file, char* buffer,
 		 * to return the exact number of bytes requested.
 		 */
 		do {
-			unsigned int read_size = size - n;
+			size_t read_size = size - n;
 			if (n > 0) {
 				Log_Printf (LOG_DEBUG, 
 					    "UpnpReadHttpGet loop ! url '%s' "

--- a/djmount/upnp_util.h
+++ b/djmount/upnp_util.h
@@ -28,6 +28,7 @@
 
 
 #include <upnp/upnptools.h>
+#include <upnp/upnp.h>
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Hi!

In my configuration (x64, libupnp version 1.6.18, "--with-external-libupnp") there are two issues:
1. Error at build in the file upnp_util.c:
`«UPNP_E_SUCCESS» undeclared (first use in this function) `
fixed by 
`#include <upnp/upnp.h>`

2. Segmentation fault error at runtime in the function `FileBuffer_Read` in the file `file_buffer.c`
`rc = UpnpCloseHttpGet (handle);`
fixed by changing type of `read_size` from `unsigned int` to `size_t`. Function UpnpReadHttpGet waits `size_t` :
EXPORT_SPEC int UpnpReadHttpGet(
	void *handle,
	char *buf,
	size_t *size,
	int timeout);

If i build without "--with-external-libupnp" configuration flag, i'm getting error:
```
[E] Error in UpnpSendAction 'Browse' -- -104 (UPNP_E_OUTOF_MEMOR)
[E] BrowseOrSearchAction ObjectId='0'
```

Thank you for great work! :+1: 